### PR TITLE
Feature/output format modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## master
 
 - Add support for SPM ([#12](https://github.com/AckeeCZ/Resizin-iOS-SDK/pull/12), kudos to [@fortmarek](https://github.com/fortmarek))
+- Add output format modifier ([#13](https://github.com/AckeeCZ/Resizin-iOS-SDK/pull/13), kudos to [@leinhauplk](https://github.com/leinhauplk))
 
 ## 0.5
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can request various transformations:
 - background color
 - alpha
 - border
+- output format
 
 ```swift
 let size = ResizinSize(cgSize: CGSize(width: 100, height: 200), scale: Int(UIScreen.main.scale))

--- a/Resizin/Classes/ResizinSettings.swift
+++ b/Resizin/Classes/ResizinSettings.swift
@@ -59,6 +59,14 @@ public struct ResizinSettings {
         case right = "90"
         case down = "180"
     }
+    
+    /// Returns the image transformed in selected format
+    public enum OutputFormat: String {
+        case jpeg
+        case png
+        case tiff
+        case webp
+    }
 
     /// Adds border (in pixels) to desired sides of the image
     public struct Border {
@@ -114,6 +122,11 @@ public struct ResizinSettings {
         }
     }
     
+    /// Output format
+    ///
+    /// `nil` value returns image in original format
+    public var outputFormat: OutputFormat?
+    
     // MARK: Inits
 
     /// Initializes a new settings for image modifications. All parameters are optional
@@ -131,7 +144,8 @@ public struct ResizinSettings {
     ///   - background: Background color of the image in hex format without #
     ///   - alpha: Alpha value of background color (0-100)
     ///   - border: Image border
-    public init(size: ResizinSize? = nil, cropMode: CropMode? = nil, gravity: Gravity? = nil, filters: [Filter]? = nil, quality: Int? = nil, rotation: Rotation? = nil, upscale: Bool? = nil, background: String? = nil, alpha: Int = 100, border: Border? = nil) {
+    ///   - outputFormat: Output format
+    public init(size: ResizinSize? = nil, cropMode: CropMode? = nil, gravity: Gravity? = nil, filters: [Filter]? = nil, quality: Int? = nil, rotation: Rotation? = nil, upscale: Bool? = nil, background: String? = nil, alpha: Int = 100, border: Border? = nil, outputFormat: OutputFormat? = nil) {
         self.size = size
         self.cropMode = cropMode
         self.gravity = gravity
@@ -142,6 +156,7 @@ public struct ResizinSettings {
         self.background = background
         self.alpha = alpha
         self.border = border
+        self.outputFormat = outputFormat
     }
     
     // MARK: Helpers
@@ -165,6 +180,8 @@ public struct ResizinSettings {
         if let upscale = upscale { modifiers.append("u_\(upscale ? 1 : 0)")}
         if let background = background { modifiers.append("bg_\(background)\(alpha)") }
         if let border = border { modifiers.append("b_\(border.top)_\(border.left)_\(border.bottom)_\(border.right)") }
+        if let outputFormat = outputFormat {
+            modifiers.append("o_\(outputFormat)") }
         return modifiers
     }
 }

--- a/Resizin/Classes/ResizinSettings.swift
+++ b/Resizin/Classes/ResizinSettings.swift
@@ -165,7 +165,7 @@ public struct ResizinSettings {
     ///   - alpha: Alpha value of background color (0-100)
     ///   - border: Image border
     ///   - outputFormat: Output format
-    public init(outputFormat: OutputFormat, size: ResizinSize? = nil, cropMode: CropMode? = nil, gravity: Gravity? = nil, filters: [Filter]? = nil, quality: Int? = nil, rotation: Rotation? = nil, upscale: Bool? = nil, background: String? = nil, alpha: Int = 100, border: Border? = nil) {
+    public init(size: ResizinSize? = nil, cropMode: CropMode? = nil, gravity: Gravity? = nil, filters: [Filter]? = nil, quality: Int? = nil, rotation: Rotation? = nil, upscale: Bool? = nil, background: String? = nil, alpha: Int = 100, border: Border? = nil, outputFormat: OutputFormat = .original) {
         self.size = size
         self.cropMode = cropMode
         self.gravity = gravity

--- a/Resizin/Classes/ResizinSettings.swift
+++ b/Resizin/Classes/ResizinSettings.swift
@@ -145,9 +145,7 @@ public struct ResizinSettings {
     }
     
     /// Output format
-    ///
-    /// `nil` value returns image in original format
-    public var outputFormat: OutputFormat?
+    public var outputFormat: OutputFormat
     
     // MARK: Inits
 
@@ -167,7 +165,7 @@ public struct ResizinSettings {
     ///   - alpha: Alpha value of background color (0-100)
     ///   - border: Image border
     ///   - outputFormat: Output format
-    public init(size: ResizinSize? = nil, cropMode: CropMode? = nil, gravity: Gravity? = nil, filters: [Filter]? = nil, quality: Int? = nil, rotation: Rotation? = nil, upscale: Bool? = nil, background: String? = nil, alpha: Int = 100, border: Border? = nil, outputFormat: OutputFormat? = nil) {
+    public init(outputFormat: OutputFormat, size: ResizinSize? = nil, cropMode: CropMode? = nil, gravity: Gravity? = nil, filters: [Filter]? = nil, quality: Int? = nil, rotation: Rotation? = nil, upscale: Bool? = nil, background: String? = nil, alpha: Int = 100, border: Border? = nil) {
         self.size = size
         self.cropMode = cropMode
         self.gravity = gravity
@@ -186,6 +184,10 @@ public struct ResizinSettings {
     /// Modifiers that will be applied on the image
     public var modifiers : [String] {
         var modifiers: [String] = []
+
+        if let outputFormat = outputFormat.stringValue {
+            modifiers.append("o_" + outputFormat)
+        }
         
         if let size = size {
             modifiers += size.modifiers
@@ -202,8 +204,6 @@ public struct ResizinSettings {
         if let upscale = upscale { modifiers.append("u_\(upscale ? 1 : 0)")}
         if let background = background { modifiers.append("bg_\(background)\(alpha)") }
         if let border = border { modifiers.append("b_\(border.top)_\(border.left)_\(border.bottom)_\(border.right)") }
-        if let outputFormat = outputFormat {
-            modifiers.append("o_\(outputFormat)") }
         return modifiers
     }
 }

--- a/Resizin/Classes/ResizinSettings.swift
+++ b/Resizin/Classes/ResizinSettings.swift
@@ -60,7 +60,7 @@ public struct ResizinSettings {
         case down = "180"
     }
     
-    /// Returns the image transformed in selected format
+    /// Returns the image transformed into the selected format
     public enum OutputFormat: String {
         case jpeg
         case png

--- a/Resizin/Classes/ResizinSettings.swift
+++ b/Resizin/Classes/ResizinSettings.swift
@@ -61,11 +61,33 @@ public struct ResizinSettings {
     }
     
     /// Returns the image transformed into the selected format
-    public enum OutputFormat: String {
+    public enum OutputFormat {
+        /// Returns image in original format
+        case original
+        /// Returns image in `JPEG` format
         case jpeg
+        /// Returns image in `PNG` format
         case png
+        /// Returns image in `TIFF` format
         case tiff
+        @available(iOS 14.0, *)
+        /// Returns image in `WEBP` format
         case webp
+        
+        var stringValue: String? {
+            switch self {
+            case .jpeg:
+                return "jpeg"
+            case .png:
+                return "png"
+            case .tiff:
+                return "tiff"
+            case .webp:
+                return "webp"
+            case .original:
+                return nil
+            }
+        }
     }
 
     /// Adds border (in pixels) to desired sides of the image


### PR DESCRIPTION
On Resizin could be images stored in multiple formats (JPG, PNG, GIF, WEBP, etc.). But some image formats may not be supported by the platform. For example, WebP is not supported on iOS lower than 14. 
Therefore, from September, Resizin began to support the transformation/conversion of images to a supported format. So we don't have to write our own image decoders, but just set `outputFormat` modifier in `ResizinSettings`.

#### Checklist
- [x] Added tests (if applicable)